### PR TITLE
fix misleading copyCodelab arguments

### DIFF
--- a/web/end/codelab_element.dart
+++ b/web/end/codelab_element.dart
@@ -54,9 +54,9 @@ class CodelabElement extends PolymerElement {
   /*
    * Copies values from source codelab to destination codelab.
    */
-  copyCodelab(source, destination) {
-    source.title = destination.title;
-    source.description = destination.description;
-    source.level = destination.level;
+  copyCodelab(destination, source) {
+    destination.title = source.title;
+    destination.description = source.description;
+    destination.level = source.level;
   }
 }


### PR DESCRIPTION
arguments source  and destination ware swapped. Source was modified based on destination's value.
See related pull request to codelab site: https://github.com/dart-lang/www.dartlang.org/pull/1146
