### PR TITLE
This is a fix for "Step 7: Editing a code lab"

### DIFF
--- a/web/end/codelab_element.dart
+++ b/web/end/codelab_element.dart
@@ -45,8 +45,10 @@ class CodelabElement extends PolymerElement {
 
   /// Copies values from source codelab to destination codelab.
   void copyCodelab(source, destination) {
-    source.title = destination.title;
-    source.description = destination.description;
-    source.level = destination.level;
+    copyCodelab(source, destination) {
+      destination.title = source.title;
+      destination.description = source.description;
+      destination.level = source.level;
+    }
   }
 }


### PR DESCRIPTION
the copyCodelab(source, destination) is wrong
As a consequence, fields were empty when editing a code lab element
