### PR TITLE
Factor out code from Codelab custom element classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .buildlog
 .pub
+.idea
+.packages
 build
 packages
 pubspec.lock

--- a/web/end/codelab_element.html
+++ b/web/end/codelab_element.html
@@ -1,54 +1,28 @@
 <link rel="import" href="packages/polymer/polymer.html">
+<link rel="import" href="item_element.html">
 
-<link rel="import" href="codelab_form.html">
-
-<polymer-element name="codelab-element" attributes="codelab">
+<polymer-element name="codelab-element" attributes="editing" extends="item-element">
   <template>
-    <style>
-      :host {
-        display: block;
-        margin: 0px;
-        margin: 12px 0;
-        background: #fcfcfc;
-        border-radius: 6px;
-      }
-      .codelab {
-        padding: 10px;
-      }
-      .codelab .field {
-        margin-bottom: 8px;
-      }
-      .codelab .field h2 {
-        font-weight: normal;
-        margin: 0px;
-        padding: 0px;
-        font-size: 1.8em;
-      }
-      .small {
-        font-size: .8em;
-      }
-    </style>
-    <div on-formNotNeeded="{{cancelEditing}}"
-         on-codelabvalidated="{{updateCodelab}}">
-      <template if="{{!editing}}">
-        <div class="codelab">
-          <div class="field">
-            <h2>{{codelab.title}}</h2>
-          </div>
-          <div class="field">
-            <p>{{codelab.description}}</p>
-          </div>
-          <div class="field">
-            <p><span>Level: </span>{{codelab.level}}</p>
-          </div>
-          <div class="field">
-            <span on-click="{{startEditing}}" class="small">Edit</span> |
-            <span on-click="{{deleteCodelab}}" class="small">Delete</span>
-          </div>
+    <shadow></shadow>
+    <div>
+    <template if="{{!editing}}">
+      <div class="item">
+        <div class="field">
+          <p><span>Level: </span>{{item.level}}</p>
         </div>
+      </div>
       </template>
       <template if="{{editing}}">
-        <codelab-form codelab="{{codelab}}"></codelab-form>
+        <div class="item">
+          <div class="field">
+            <label>Level: </label>
+            <select value="{{item.level}}">
+              <option template repeat="{{level in allLevels}}">
+                {{level}}
+              </option>
+            </select>
+          </div>
+        </div>
       </template>
     </div>
   </template>

--- a/web/end/codelab_form.dart
+++ b/web/end/codelab_form.dart
@@ -1,72 +1,44 @@
 import 'package:polymer/polymer.dart';
 import 'model.dart' show Codelab;
 import 'dart:html' show CustomEvent, Event, Node;
+import 'item_form.dart' show ItemFormElement;
 
 /*
  * The class for creating or updating a codelab. Performs validation based on
  * a codelab based on validation rules defined in the model.
  */
 @CustomTag('codelab-form')
-class CodelabFormElement extends PolymerElement {
-  /// The Codelab object modified by this form.
-  @published Codelab codelab;
+class CodelabFormElement extends ItemFormElement {
 
   /// Getters that make Codelab static values accessible in the template.
   List<String> get allLevels => Codelab.LEVELS;
-  int get minTitleLength => Codelab.MIN_TITLE_LENGTH;
-  int get maxTitleLength => Codelab.MAX_TITLE_LENGTH;
-  int get maxDescriptionLength => Codelab.MAX_DESCRIPTION_LENGTH;
-
-  /// Variables used in displaying error messages.
-  @observable String titleErrorMessage = '';
-  @observable String descriptionErrorMessage = '';
 
   CodelabFormElement.created() : super.created() {}
 
   /// Validates the codelab title. If title is not valid, sets error message and
   /// returns false. Otherwise, removes error message and returns true.
   bool validateTitle() {
-    if (codelab.title.length < minTitleLength ||
-        codelab.title.length > maxTitleLength) {
-      titleErrorMessage = "Title must be between $minTitleLength and "
-          "$maxTitleLength characters.";
-      return false;
-    }
-    titleErrorMessage = '';
-    return true;
+    return super.validateTitle();
   }
 
   /// Validates the codelab description. If description is not valid, sets error
   /// message and returns false. Otherwise, removes error message and returns
   /// true.
   bool validateDescription() {
-    if (codelab.description.length > maxDescriptionLength) {
-      descriptionErrorMessage = "Description cannot be more than "
-          "$maxDescriptionLength characters.";
-      return false;
-    }
-    descriptionErrorMessage = '';
-    return true;
+    return super.validateDescription();
   }
 
   /// Dispatches a custom event if a codelab passes validation. Otherwise, sets
   /// the form error message. It is up to the form's parent element to listen
   /// for the dispatch and handle the validated codelab object.
-  void validateCodelab(Event event, Object detail, Node sender) {
-    event.preventDefault();
-    if (validateTitle() && validateDescription()) {
-      dispatchEvent(new CustomEvent('codelabvalidated',
-          detail: {'codelab': codelab}));
-    }
+  void validateItem(Event event, Object detail, Node sender) {
+    super.validateItem(event, detail, sender);
   }
 
   /// Dispatches a custom event when a form is no longer needed. It is up to the
   /// form's parent elemnt to listen for the dispatch and handle a form that
   /// isn't being used.
   void cancelForm(Event event, Object detail, Node sender) {
-    event.preventDefault();
-    titleErrorMessage = '';
-    descriptionErrorMessage = '';
-    dispatchEvent(new CustomEvent('formnotneeded'));
+    super.cancelForm(event, detail, sender);
   }
 }

--- a/web/end/codelab_form.html
+++ b/web/end/codelab_form.html
@@ -1,115 +1,18 @@
 <link rel="import" href="packages/polymer/polymer.html">
+<link rel="import" href="item_form.html">
 
-<polymer-element name="codelab-form" attributes="codelab">
+<polymer-element name="codelab-form" extends="item-form">
   <template>
-    <style>
-      :host {
-        display: block;
-        margin: 0px;
-      }
-      form {
-        padding: 20px;
-        background: #fafafa;
-        border-radius: 6px;
-      }
-      textarea {
-        display: block;
-        width: 90%;
-        height: 30px;
-        padding: 4px 8px;
-        font-size: 13px;
-        line-height: 2.3;
-        color: #555;
-        background: #fff;
-        border: 1px solid #ccc;
-        border-radius: 3px;
-        box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-        transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
-        margin-bottom: 5px;
-      }
-      .error {
-        color: red;
-        font-size: .9em;
-        font-style: italic;
-        margin-left: 10px;
-      }
-      .field {
-        margin-bottom: 12px;
-      }
-      button {
-        color: #333;
-        border-color: #ccc;
-        display: inline-block;
-        margin-bottom: 0;
-        font-weight: 400;
-        text-align: center;
-        vertical-align: middle;
-        cursor: pointer;
-        background-image: none;
-        border: 1px solid #555;
-        white-space: nowrap;
-        padding: 6px 12px;
-        font-size: 14px;
-        line-height: 1.42857143;
-        border-radius: 4px;
-      }
-      select {
-        height: 40px;
-        width: 50%;
-        height: 30px;
-        padding: 6px 12px;
-        font-size: 14px;
-        line-height: 1.42857143;
-        color: #555;
-        background-color: #fff;
-        background-image: none;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-        box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-        -webkit-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
-        transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
-      }
-    </style>
-
-    <form on-submit="{{validateCodelab}}">
+      <shadow></shadow>
       <div class="field">
-        <textarea placeholder="Add title" value="{{codelab.title}}"
-            on-keyup="{{validateTitle}}">
-        </textarea>
-        <div>
-          <span class="chars-left">{{maxTitleLength - codelab.title.length}}</span>
-          <span class="error" hidden?="{{titleErrorMessage.isEmpty}}">
-            {{titleErrorMessage}}
-          </span>
-        </div>
-      </div>
-      <div class="field">
-        <textarea placeholder="Add description" value="{{codelab.description}}"
-            on-keyup="{{validateDescription}}">
-        </textarea>
-        <div>
-          <span class="chars-left">
-            {{maxDescriptionLength - codelab.description.length}}
-          </span>
-          <span class="error" hidden?="{{descriptionErrorMessage.isEmpty}}">
-            {{descriptionErrorMessage}}
-          </span>
-        </div>
-      </div>
-      <div class="field">
+        <!-- TODO: refactor: duplicated in <item-element> -->
         <label>Level: </label>
-        <select value="{{codelab.level}}">
+        <select value="{{item.level}}">
           <option template repeat="{{level in allLevels}}">
             {{level}}
           </option>
         </select>
       </div>
-      <div>
-        <button type="submit">Submit</button>
-        <button type="button" on-click="{{cancelForm}}">Cancel</button>
-      </div>
-    </form>
   </template>
   <script type="application/dart" src="codelab_form.dart"></script>
 </polymer-element>

--- a/web/end/codelab_list.dart
+++ b/web/end/codelab_list.dart
@@ -1,16 +1,12 @@
 import 'package:polymer/polymer.dart';
 import 'model.dart' show Codelab;
+import 'item_list.dart' show ItemList;
 import 'dart:html' show Event, Node;
 
 /// Class to represent a collection of Codelab objects.
 @CustomTag('codelab-list')
-class CodelabList extends PolymerElement {
+class CodelabList extends ItemList {
   static const ALL = "all";
-  /// Field for a new Codelab object.
-  @observable Codelab newCodelab = new Codelab();
-
-  /// Collection of codelabs. The source of truth for all codelabs in this app.
-  @observable List<Codelab> codelabs = toObservable([]);
 
   /// Sets the new codelab form to default to the intermediate level.
   String get defaultLevel => Codelab.LEVELS[1];
@@ -23,48 +19,47 @@ class CodelabList extends PolymerElement {
   @observable String filterValue = ALL;
 
   /// The list of filtered codelabs.
-  @observable List<Codelab> filteredCodelabs = toObservable([]);
+  @observable List<Codelab> filteredItems = toObservable([]);
 
   /// Named constructor. Sets initial value of filtered codelabs and sets
   /// the new codelab's level to the default.
   CodelabList.created() : super.created() {
-    filteredCodelabs = codelabs;
-    newCodelab.level = defaultLevel;
+    filteredItems = items;
+    newItem = new Codelab();
+    newItem.level = defaultLevel;
   }
 
   /// Replaces the existing new Codelab, causing the new codelab form to reset.
   void resetForm() {
-    newCodelab = new Codelab();
-    newCodelab.level = defaultLevel;
+    newItem = new Codelab();
+    newItem.level = defaultLevel;
+    super.resetForm();
   }
 
   /// Adds a codelab to the codelabs list and resets the new codelab form. This
   /// triggers codelabsChanged().
-  void addCodelab(Event e, var detail, Node sender) {
-    e.preventDefault();
-    codelabs.add(detail['codelab']);
-    resetForm();
+  void addItem(Event e, var detail, Node sender) {
+    super.addItem(e, detail, sender);
   }
 
   /// Removes a codelab from the codelabs list. This triggers codelabsChanged().
-  void deleteCodelab(Event e, var detail, Node sender) {
-    var codelab = detail['codelab'];
-    codelabs.remove(codelab);
+  void deleteItem(Event e, var detail, Node sender) {
+    super.deleteItem(e, detail, sender);
   }
 
   /// Calculates the codelabs to display when using a filter.
   void filter() {
     if (filterValue == ALL) {
-      filteredCodelabs = codelabs;
+      filteredItems = items;
       return;
     }
-    filteredCodelabs = codelabs.where((codelab) {
-      return codelab.level == filterValue;
+    filteredItems = items.where((item) {
+      return item.level == filterValue;
     }).toList();
   }
 
   /// Refreshes the filtered codelabs list every time the codelabs list changes.
-  void codelabsChanged() {
+  void itemsChanged() {
     filter();
   }
 }

--- a/web/end/codelab_list.html
+++ b/web/end/codelab_list.html
@@ -2,27 +2,12 @@
 
 <link rel="import" href="codelab_form.html">
 <link rel="import" href="codelab_element.html">
+<link rel="import" href="item_list.html">
 
-<polymer-element name="codelab-list">
+<polymer-element name="codelab-list" extends="item-list">
   <template>
-    <style>
-      select {
-        margin-bottom: 30px;
-        display: inline;
-        padding: 6px 12px;
-        font-size: 14px;
-        line-height: 1.42857143;
-        color: #555;
-        background-color: #fff;
-        background-image: none;
-        border: 1px solid #ccc;
-        border-radius: 2px;
-        -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-        box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-        -webkit-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
-        transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
-      }
-    </style>
+		<shadow></shadow>
+		<!-- TODO: determine how to put some of this into base class. -->
     <div>
       <label>Filter: </label>
       <select value="{{filterValue}}" on-change="{{filter}}">
@@ -31,14 +16,14 @@
         </option>
       </select>
     </div>
-    <div on-codelabvalidated="{{addCodelab}}"
+    <div on-itemvalidated="{{addItem}}"
          on-formnotneeded="{{resetForm}}">
-      <codelab-form codelab="{{newCodelab}}"></codelab-form>
+      <codelab-form item="{{newItem}}" editing="{{true}}"></codelab-form>
     </div>
-    <div on-deletecodelab="{{deleteCodelab}}"
+    <div on-deleteitem="{{deleteItem}}"
          on-levelchanged="{{filter}}">
-      <template repeat="{{codelab in filteredCodelabs}}">
-        <codelab-element codelab="{{codelab}}"></codelab-element>
+      <template repeat="{{item in filteredItems}}">
+        <codelab-element item="{{item}}"></codelab-element>
       </template>
     </div>
   </template>

--- a/web/end/item.dart
+++ b/web/end/item.dart
@@ -1,0 +1,20 @@
+library polymer_and_dart.web.models;
+
+import 'package:polymer/polymer.dart';
+
+
+abstract class Item extends Observable {
+
+  @observable String title;
+  @observable String description;
+
+  static const MIN_TITLE_LENGTH = 10;
+  static const MAX_TITLE_LENGTH = 30;
+  static const MAX_DESCRIPTION_LENGTH = 140;
+
+  /*
+   * Allow a subclass instance to be generated with
+   * an empty argument list
+   */
+  Item(this.title, this.description);
+}

--- a/web/end/item_element.dart
+++ b/web/end/item_element.dart
@@ -1,44 +1,51 @@
 import 'package:polymer/polymer.dart';
-import 'model.dart' show Codelab;
+import 'item.dart' show Item;
 import 'dart:html' show Event, Node, CustomEvent;
-import 'item_element.dart' show ItemElement;
 
-@CustomTag('codelab-element')
-class CodelabElement extends ItemElement {
+@CustomTag('item-element')
+class ItemElement extends PolymerElement {
+  @published Item item;
+  @observable bool editing = false;
+  Item _cachedItem;
 
-  CodelabElement.created() : super.created() {}
+  ItemElement.created() : super.created() {}
 
-  /// Getters that make Codelab static values accessible in the template.
-  List<String> get allLevels => Codelab.LEVELS;
+	/// Make private variable accessible by subclasses
+	Item get cachedItem => _cachedItem;
+	set cachedItem(item) => _cachedItem = item;
 
   /// Updates codelab. If the codelab's level has changed, dispatches a
   /// custom event. This allows the element's parent to register a listener to
   /// update the filtered codelabs list.
   void updateItem(Event e, var detail, Node sender) {
-    super.updateItem(e, detail, sender);
-    if (cachedItem.level != item.level) {
-      dispatchEvent(new CustomEvent('levelchanged'));
-    }
+    e.preventDefault();
+    editing = false;
   }
 
   /// Cancels editing, restoring the original codelab values.
   void cancelEditing(Event e, var detail, Node sender) {
-		super.cancelEditing(e, detail, sender);
+    e.preventDefault();
+    copyItem(_cachedItem, item);
+    editing = false;
   }
 
   /// Starts editing, caching the codelab values.
   void startEditing(Event e, var detail, Node sender) {
-    cachedItem = new Codelab();
-		super.startEditing(e, detail, sender);
+    e.preventDefault();
+    copyItem(item, _cachedItem);
+    editing = true;
   }
 
   /// Dispatches a custom event requesting the codelab be deleted.
   void deleteItem(Event e, var detail, Node sender) {
-		super.deleteItem(e, detail, sender);
+    e.preventDefault();
+    dispatchEvent(new CustomEvent('deleteitem',
+        detail: {'item': item}));
   }
 
   /// Copies values from source codelab to destination codelab.
   void copyItem(source, destination) {
-		super.copyItem(source, destination);
+      destination.title = source.title;
+      destination.description = source.description;
   }
 }

--- a/web/end/item_element.html
+++ b/web/end/item_element.html
@@ -1,0 +1,56 @@
+<link rel="import" href="packages/polymer/polymer.html">
+
+<link rel="import" href="item_form.html">
+
+<polymer-element name="item-element" attributes="item">
+  <template>
+    <style>
+      :host {
+        display: block;
+        margin: 0px;
+        margin: 12px 0;
+        background: #fcfcfc;
+        border-radius: 6px;
+      }
+      .codelab {
+        padding: 10px;
+      }
+      .codelab .field {
+        margin-bottom: 8px;
+      }
+      .codelab .field h2 {
+        font-weight: normal;
+        margin: 0px;
+        padding: 0px;
+        font-size: 1.8em;
+      }
+      .small {
+        font-size: .8em;
+      }
+    </style>
+    <div on-formNotNeeded="{{cancelEditing}}"
+         on-itemvalidated="{{updateItem}}">
+      <template if="{{!editing}}">
+        <content></content>
+        <div class="item">
+          <div class="field">
+            <h2>{{item.title}}</h2>
+          </div>
+          <div class="field">
+            <p>{{item.description}}</p>
+          </div>
+          <div class="field">
+            <span on-click="{{startEditing}}" class="small">Edit</span> |
+            <span on-click="{{deleteItem}}" class="small">Delete</span>
+          </div>
+        </div>
+      </template>
+      <template if="{{editing}}">
+        <item-form item="{{item}}">
+          <content></content>
+        </item-form>
+      </template>
+    </div>
+  </template>
+  <script type="application/dart" src="item_element.dart"></script>
+</polymer-element>

--- a/web/end/item_form.dart
+++ b/web/end/item_form.dart
@@ -1,0 +1,72 @@
+import 'package:polymer/polymer.dart';
+import 'item.dart' show Item;
+import 'dart:html' show CustomEvent, Event, Node;
+
+/*
+ * The class for creating or updating a codelab. Performs validation based on
+ * a codelab based on validation rules defined in the model.
+ */
+
+@CustomTag('item-form')
+class ItemFormElement extends PolymerElement {
+  /// The Codelab object modified by this form.
+  @published Item item;
+
+  /// Getters that make Codelab static values accessible in the template.
+  int get minTitleLength => Item.MIN_TITLE_LENGTH;
+  int get maxTitleLength => Item.MAX_TITLE_LENGTH;
+  int get maxDescriptionLength => Item.MAX_DESCRIPTION_LENGTH;
+
+  /// Variables used in displaying error messages.
+  @observable String titleErrorMessage = '';
+  @observable String descriptionErrorMessage = '';
+
+  ItemFormElement.created() : super.created() {}
+
+  /// Validates the codelab title. If title is not valid, sets error message and
+  /// returns false. Otherwise, removes error message and returns true.
+  bool validateTitle() {
+    if (item.title.length < minTitleLength ||
+        item.title.length > maxTitleLength) {
+      titleErrorMessage = "Title must be between $minTitleLength and "
+          "$maxTitleLength characters.";
+      return false;
+    }
+    titleErrorMessage = '';
+    return true;
+  }
+
+  /// Validates the codelab description. If description is not valid, sets error
+  /// message and returns false. Otherwise, removes error message and returns
+  /// true.
+  bool validateDescription() {
+    if (item.description.length > maxDescriptionLength) {
+      descriptionErrorMessage = "Description cannot be more than "
+          "$maxDescriptionLength characters.";
+      return false;
+    }
+    descriptionErrorMessage = '';
+    return true;
+  }
+
+  /// Dispatches a custom event if a codelab passes validation. Otherwise, sets
+  /// the form error message. It is up to the form's parent element to listen
+  /// for the dispatch and handle the validated codelab object.
+  void validateItem(Event event, Object detail, Node sender) {
+    event.preventDefault();
+    if (validateTitle() && validateDescription()) {
+      dispatchEvent(new CustomEvent('itemvalidated',
+          detail: {'item': item}));
+    }
+  }
+
+  /// Dispatches a custom event when a form is no longer needed. It is up to the
+  /// form's parent elemnt to listen for the dispatch and handle a form that
+  /// isn't being used.
+  void cancelForm(Event event, Object detail, Node sender) {
+    event.preventDefault();
+    titleErrorMessage = '';
+    descriptionErrorMessage = '';
+    dispatchEvent(new CustomEvent('formnotneeded'));
+  }
+}

--- a/web/end/item_form.html
+++ b/web/end/item_form.html
@@ -1,0 +1,106 @@
+<link rel="import" href="packages/polymer/polymer.html">
+
+<polymer-element name="item-form" attributes="item">
+  <template>
+    <style>
+      :host {
+        display: block;
+        margin: 0px;
+      }
+      form {
+        padding: 20px;
+        background: #fafafa;
+        border-radius: 6px;
+      }
+      textarea {
+        display: block;
+        width: 90%;
+        height: 30px;
+        padding: 4px 8px;
+        font-size: 13px;
+        line-height: 2.3;
+        color: #555;
+        background: #fff;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+        transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+        margin-bottom: 5px;
+      }
+      .error {
+        color: red;
+        font-size: .9em;
+        font-style: italic;
+        margin-left: 10px;
+      }
+      .field {
+        margin-bottom: 12px;
+      }
+      button {
+        color: #333;
+        border-color: #ccc;
+        display: inline-block;
+        margin-bottom: 0;
+        font-weight: 400;
+        text-align: center;
+        vertical-align: middle;
+        cursor: pointer;
+        background-image: none;
+        border: 1px solid #555;
+        white-space: nowrap;
+        padding: 6px 12px;
+        font-size: 14px;
+        line-height: 1.42857143;
+        border-radius: 4px;
+      }
+      select {
+        height: 40px;
+        width: 50%;
+        height: 30px;
+        padding: 6px 12px;
+        font-size: 14px;
+        line-height: 1.42857143;
+        color: #555;
+        background-color: #fff;
+        background-image: none;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+        box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+        -webkit-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+        transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+      }
+    </style>
+
+    <form on-submit="{{validateItem}}">
+      <div class="field">
+        <textarea placeholder="Add title" value="{{item.title}}"
+            on-keyup="{{validateTitle}}">
+        </textarea>
+        <div>
+          <span class="chars-left">{{maxTitleLength - item.title.length}}</span>
+          <span class="error" hidden?="{{titleErrorMessage.isEmpty}}">
+            {{titleErrorMessage}}
+          </span>
+        </div>
+      </div>
+      <div class="field">
+        <textarea placeholder="Add description" value="{{item.description}}"
+            on-keyup="{{validateDescription}}">
+        </textarea>
+        <div>
+          <!--span class="chars-left">{{maxDescriptionLength - item.description.length}}</span-->
+          <span class="error" hidden?="{{descriptionErrorMessage.isEmpty}}">
+            {{descriptionErrorMessage}}
+          </span>
+        </div>
+      </div>
+        <content></content>
+      <div>
+        <button type="submit">Submit</button>
+        <button type="button" on-click="{{cancelForm}}">Cancel</button>
+      </div>
+    </form>
+  </template>
+  <script type="application/dart" src="item_form.dart"></script>
+</polymer-element>

--- a/web/end/item_list.dart
+++ b/web/end/item_list.dart
@@ -1,0 +1,36 @@
+import 'package:polymer/polymer.dart';
+import 'item.dart' show Item;
+import 'dart:html' show Event, Node;
+
+/// Class to represent a collection of Codelab objects.
+@CustomTag('item-list')
+class ItemList extends PolymerElement {
+  /// Field for a new Codelab object.
+  @observable Item newItem;
+
+  /// Collection of codelabs. The source of truth for all codelabs in this app.
+  @observable List<Item> items = toObservable([]);
+
+  /// Named constructor. Sets initial value of filtered codelabs and sets
+  /// the new codelab's level to the default.
+  ItemList.created() : super.created();
+
+  /// Replaces the existing new Codelab, causing the new codelab form to reset.
+  void resetForm() {
+    print("ItemList::resetForm()");
+  }
+
+  /// Adds a codelab to the codelabs list and resets the new codelab form. This
+  /// triggers codelabsChanged().
+  void addItem(Event e, var detail, Node sender) {
+    e.preventDefault();
+    items.add(detail['item']);
+    resetForm();
+  }
+
+  /// Removes a codelab from the codelabs list. This triggers codelabsChanged().
+  void deleteItem(Event e, var detail, Node sender) {
+    var item = detail['item'];
+    items.remove(item);
+  }
+}

--- a/web/end/item_list.html
+++ b/web/end/item_list.html
@@ -1,0 +1,31 @@
+<link rel="import" href="packages/polymer/polymer.html">
+
+<link rel="import" href="codelab_form.html">
+<link rel="import" href="codelab_element.html">
+
+<polymer-element name="item-list">
+  <template>
+    <!-- Implementation totally in subclass for now -->
+    <!-- TODO: determine how to insert subclass elements -->
+    <style>
+      select {
+        margin-bottom: 30px;
+        display: inline;
+        padding: 6px 12px;
+        font-size: 14px;
+        line-height: 1.42857143;
+        color: #555;
+        background-color: #fff;
+        background-image: none;
+        border: 1px solid #ccc;
+        border-radius: 2px;
+        -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+        box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+        -webkit-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+        transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+      }
+    </style>
+    <content></content>
+  </template>
+  <script type="application/dart" src="item_list.dart"></script>
+</polymer-element>

--- a/web/end/model.dart
+++ b/web/end/model.dart
@@ -1,17 +1,13 @@
 library polymer_and_dart.web.models;
 
 import 'package:polymer/polymer.dart';
+import 'item.dart' show Item;
 
 /// The barebones model for a codelab. Defines constants used for validation.
-class Codelab extends Observable {
+class Codelab extends Item {
   static const List<String> LEVELS = const ['easy', 'intermediate', 'advanced'];
-  static const MIN_TITLE_LENGTH = 10;
-  static const MAX_TITLE_LENGTH = 30;
-  static const MAX_DESCRIPTION_LENGTH = 140;
 
-  @observable String title;
-  @observable String description;
   @observable String level;
 
-  Codelab([this.title = "", this.description = ""]);
+  Codelab([title = "", description = ""]) : super(title, description);
 }


### PR DESCRIPTION
The goal was to reduce as much as possible the size of the Codelab element Dart classes and Polymer components and thus make it possible to add new content types (in addition to Codelab) to the application with far less coding required.
